### PR TITLE
adds past present future styleing to hour blocks

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,14 +23,25 @@ $(function () {
   }
 
   function renderTimeBlocks(timeBlocks) {
+    var thisHour = parseInt(dayjs().format("H"));
+    var pastPresentFuture;
+
     timeBlocksContainer.empty();
     for (var i = 0; i < timeBlocks.length; i++) {
       var amPm = timeBlocks[i].time < 12 ? "am" : "pm";
       var hour = timeBlocks[i].time % 12;
       if (hour === 0) hour = 12;
 
+      if (timeBlocks[i].time < thisHour) {
+        pastPresentFuture = "past";
+      } else if (timeBlocks[i].time === thisHour) {
+        pastPresentFuture = "present";
+      } else {
+        pastPresentFuture = "future";
+      }
+
       var newTimeBlockEl =
-        $(`<div id="hour-${hour}" class="row time-block past">
+        $(`<div id="hour-${hour}" class="row time-block ${pastPresentFuture}">
         <div class="col-2 col-md-1 hour text-center py-3">${hour}${amPm}</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">


### PR DESCRIPTION
This adds timeblocks with color coding for past present and future. Here are the files I've changed:

 script.js
- adds logic style each time block based on whether it's in the past, present or future


 it should look like this for you to approve:
 
<img width="1338" alt="Screenshot 2023-08-29 at 2 25 49 PM" src="https://github.com/benjaminbwright/day-planner-with-branches/assets/5744219/f6646875-ff7e-4aa1-9f31-a8e294a3c77a">
